### PR TITLE
Обновил ссылку в readme.md для приложения 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![GitHub Actions](https://github.com/Hexlet/jsbrowser/workflows/Node%20CI/badge.svg)](https://github.com/Hexlet/jsbrowser/actions/workflows/nodejs.yml)
 
-https://jsbrowser.herokuapp.com/
+https://hexlet.github.io/jsbrowser/
 
 # jsbrowser
 


### PR DESCRIPTION
Обновил ссылку на деплой приложения развернутого на GitHub Pages.

Но нужно сделать деплой приложения для данного репозитория, владельцу репозитория нужно набрать две команды:
`make build`
`make github-deploy`

После этого по обновленной в README.md ссылке будет доступно приложение.